### PR TITLE
Do not force class elements to be ordered alphabetically and per visibility

### DIFF
--- a/resources/php-cs-fixer/configs/phpcsfixer.rules.php.yml
+++ b/resources/php-cs-fixer/configs/phpcsfixer.rules.php.yml
@@ -43,20 +43,14 @@ parameters:
         ordered_class_elements:
             order:
                 - use_trait
-                - constant_public
-                - constant_protected
-                - constant_private
-                - property_public
-                - property_protected
-                - property_private
+                - constant
+                - property
                 - construct
                 - destruct
                 - magic
                 - phpunit
-                - method_public
-                - method_protected
-                - method_private
-            sortAlgorithm: alpha
+                - method
+            sortAlgorithm: none
         ordered_imports: ~
         phpdoc_align: false
         phpdoc_annotation_without_dot: false


### PR DESCRIPTION
The `php-cs-fixer` rule that forces class elements to be ordered alphabetically and per visibility is preventing developers from grouping related elements. For example forcing constants to be alphabetical can cause a group of related constants to have an unrelated constant forced in between them. The visibility ordering is equally counterproductive: for example a public method that defers its logic to a protected recursive method is now forced far apart at opposite sides of the class.