### PR TITLE
OEL-2035: Bump drupal/coder, allow PHP attributes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
   "license": "EUPL-1.2",
   "require": {
     "php": ">=7.4",
-    "drupal/coder": "^8.3.13",
+    "drupal/coder": "^8.3.16",
     "phpmd/phpmd" : "^2.12",
     "phpro/grumphp": "^1.1",
     "squizlabs/php_codesniffer": "^3.6",

--- a/tests/fixtures/phpcs/DrupalClass.php
+++ b/tests/fixtures/phpcs/DrupalClass.php
@@ -18,4 +18,11 @@ class DrupalClass extends BlockBase {
     return true;
   }
 
+  /**
+   * Tests method with docblock and PHP attribute.
+   */
+  #[\ReturnTypeWillChange]
+  public function aMethodWithDocblockAndPhpAttribute(): void {
+  }
+
 }


### PR DESCRIPTION
##  See [OEL-2035](https://citnet.tech.ec.europa.eu/CITnet/jira/browse/OEL-2035)
