### PR TITLE
EWPP-6348: Lock grumphp-shim to 2.17.0 until it is fixed.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,12 +4,17 @@
   "license": "EUPL-1.2",
   "require": {
     "php": ">=8.1",
-    "phpro/grumphp-shim": "^2.7"
+    "phpro/grumphp-shim": "2.17.0"
   },
   "config": {
     "allow-plugins": {
       "dealerdirect/phpcodesniffer-composer-installer": true,
       "phpro/grumphp-shim": true
     }
+  },
+  "extra": {
+    "_readme": [
+      "Locking grumphp-shim because 2.18.0 version has broken requirements check."
+    ]
   }
 }


### PR DESCRIPTION
## EWPP-6348

### Description

The latest release https://github.com/phpro/grumphp/releases/tag/v2.18.0 has a broken phar version due to requirements problem. The goal of this PR is to switch temporarily to "standard" version of grumphp.

